### PR TITLE
fix(PG-103/A4): Remove xfail markers from passing stats-CLI tests

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -88,7 +88,6 @@ def pytest_collection_modifyitems(config, items):
         "test_idempotency": "legacy-deprecated: Idempotency logic changed",
         "test_partial_results_handling": "legacy-deprecated: Partial results handling changed",
         "test_phase_results_tracking": "legacy-deprecated: Phase tracking changed",
-        "test_empty_results_handling": "legacy-deprecated: Empty results handling changed",
         "test_api_scraping_stub": "legacy-deprecated: API scraping removed",
         "test_invalid_csv_handling": "legacy-deprecated: CSV validation changed",
         "test_settled_timestamp": "legacy-deprecated: Timestamp handling changed",

--- a/tests/test_stats_main.py
+++ b/tests/test_stats_main.py
@@ -135,7 +135,6 @@ class TestStatsMain:
         assert 'saved to' in result.output
     
     @patch('scripts.stats.StatsGenerator')
-    @pytest.mark.xfail(reason="Legacy test - needs update")
     def test_main_error_handling(self, mock_generator_class, runner):
         """Test main error handling."""
         mock_generator_class.side_effect = Exception("Test error")


### PR DESCRIPTION
## Problem
Two stats-CLI tests were passing but marked as xfail, causing XPASS warnings in test output:
- `test_empty_results_handling` 
- `test_main_error_handling`

## Solution
- Removed `test_empty_results_handling` from conftest.py xfail list (line 91)
- Removed xfail decorator from `test_main_error_handling` in test_stats_main.py (line 138)
- All stats tests now pass with no XPASS warnings
- Stats test results: 29 passed, 3 skipped, 2 xfailed, 0 xpassed ✅

## Testing
```bash
# Run stats-specific tests
pytest tests/test_stats_cli.py tests/test_stats_main.py -v

# Verify overall coverage maintained
pytest --cov=phasegrid --cov-report=term --cov-fail-under=80
Results

✅ Fixed 2 XPASS tests → now properly passing
✅ Coverage maintained at 80.61% (exceeds 80% requirement)
✅ All Python versions (3.9-3.13) ready for CI
✅ No breaking changes to existing functionality

Files Changed

conftest.py - Removed test_empty_results_handling from legacy_xfail_tests dict
tests/test_stats_main.py - Removed @pytest.mark.xfail decorator

Closes #103