### PR TITLE
A5: Coverage Dip RCA - No drop found, CI threshold fixed

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,7 +29,7 @@ jobs:
     
     - name: Run tests with coverage
       run: |
-        pytest --cov=phasegrid --cov-report=term-missing --cov-report=xml --cov-fail-under=20
+        pytest --cov=phasegrid --cov-report=term-missing --cov-report=xml --cov-fail-under=80
     
     - name: Upload coverage reports
       uses: actions/upload-artifact@v4
@@ -40,3 +40,4 @@ jobs:
           coverage.xml
           htmlcov/
         retention-days: 30
+


### PR DESCRIPTION
## A5: Coverage Dip Root Cause Analysis

### Summary
Investigation into reported coverage drop from "80+%" to "71.2%" revealed **no actual drop occurred**.

### Findings
- ✅ Current coverage: **81.00%** (exceeds 80% requirement)  
- ❌ CI misconfigured: Was requiring only 20% instead of 80%
- ❓ 71.2% figure: Not found in codebase - likely miscommunication

### Changes
- Updated `.github/workflows/tests.yml`: `--cov-fail-under=20` → `--cov-fail-under=80`
- pyproject.toml already updated: 14% → 80%

### Evidence
Name                          Stmts   Miss   Cover
phasegrid                       521     99  81.00%  ✅

No further action required - coverage healthy and CI now enforces correct threshold.